### PR TITLE
feat: Implement client CLI to test server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "ua-detect-client"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "fakeit",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "ua-detect-validate",
+]
+
+[[package]]
 name = "ua-detect-server"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ ua-detect-validate = { path = "crates/validate" }
 clap = "4.4.0"
 fakeit = "1.1.2"
 prost = "0.11"
+rand = "0.8.5"
 thiserror = "1.0.47"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tonic = "0.9"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ua-detect-client"
+description = "Client CLI for communicating with the ua-detect service"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+clap.workspace = true
+fakeit.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tonic.workspace = true
+ua-detect-validate.workspace = true
+
+[dev-dependencies]

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -1,0 +1,132 @@
+use std::process::ExitCode;
+
+use clap::{value_parser, Arg, Command, ValueHint};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use thiserror::Error;
+use tonic::transport::Uri;
+use ua_detect_validate::{
+    validate_client::ValidateClient, ValidateUserAgentRequest, ValidateUserAgentResponse, Validity,
+};
+
+#[derive(Clone)]
+enum UserAgent {
+    Chrome,
+    Firefox,
+    Safari,
+    Opera,
+    Other(String),
+}
+
+// TODO: The ValueEnum stuff in clap doesn't allow for catch-all so we fake it
+impl From<String> for UserAgent {
+    fn from(s: String) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "chrome" => Self::Chrome,
+            "firefox" => Self::Firefox,
+            "safari" => Self::Safari,
+            "opera" => Self::Opera,
+            _ => Self::Other(s),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+enum ClientError {
+    #[error("Invalid values specified for `--url`")]
+    InvalidUrl,
+
+    #[error("Missing scheme in `--url` - try adding `http://` or `https://`")]
+    MissingScheme,
+}
+
+fn get_arguments() -> Result<(Uri, String), ClientError> {
+    let args = Command::new("ua-detect-client")
+        .author("Blaine Bublitz <blaine.bublitz@gmail.com>")
+        .version("0.0.0")
+        .about("Communicate with the ua-detect gRPC server")
+        .arg(
+            Arg::new("url")
+                .long("url")
+                .help("The url to the running ua-detect service")
+                .value_hint(ValueHint::Url)
+                .value_parser(value_parser!(Uri))
+                .default_value("http://[::1]:9001"),
+        )
+        .arg(Arg::new("user-agent").value_parser(value_parser!(UserAgent)).help("The full user-agent to validate or a shorthand helper [chrome, firefox, safari, opera]"))
+        .get_matches();
+
+    let url = args.get_one::<Uri>("url").ok_or(ClientError::InvalidUrl)?;
+    if url.scheme().is_none() {
+        return Err(ClientError::MissingScheme);
+    }
+    let user_agent = match args.get_one::<UserAgent>("user-agent") {
+        Some(UserAgent::Chrome) => fakeit::user_agent::chrome(),
+        Some(UserAgent::Firefox) => fakeit::user_agent::firefox(),
+        Some(UserAgent::Safari) => fakeit::user_agent::safari(),
+        Some(UserAgent::Opera) => fakeit::user_agent::opera(),
+        Some(UserAgent::Other(user_agent)) => user_agent.clone(),
+        None => {
+            let mut rng = thread_rng();
+            let mut user_agent = [
+                fakeit::user_agent::opera(),
+                fakeit::user_agent::chrome(),
+                fakeit::user_agent::firefox(),
+                fakeit::user_agent::safari(),
+            ];
+            // TODO: The shuffle + clone are currently working around a lifetime issue that I didn't look into
+            user_agent.shuffle(&mut rng);
+            user_agent[0].clone()
+        }
+    };
+
+    Ok((url.clone(), user_agent))
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    // TODO(#4): Come up with an abstraction that could "unwrap" errors but still print the error messages we want
+    // TODO: Abstract the various Result returning functions so they return our `ClientError` types instead of hardcoding the error messages
+    // This pyramid was needed because the rust runtime debug prints the message instead of display printing it for Result return types
+    match get_arguments() {
+        Ok((url, user_agent)) => match ValidateClient::connect(url).await {
+            Ok(mut validator) => {
+                let request = tonic::Request::new(ValidateUserAgentRequest {
+                    user_agent: user_agent.clone().into(),
+                });
+
+                match validator.user_agent(request).await {
+                    Ok(response) => {
+                        let ValidateUserAgentResponse { validity } = response.into_inner();
+                        match Validity::from_i32(validity) {
+                            Some(validity) => {
+                                match validity {
+                                    Validity::Valid => println!("{user_agent} => Valid"),
+                                    Validity::Invalid => println!("{user_agent} => Invalid"),
+                                    Validity::Unknown => println!("{user_agent} => Unknown"),
+                                }
+                                ExitCode::SUCCESS
+                            }
+                            None => {
+                                eprintln!("Error: Invalid response from the endpoint");
+                                ExitCode::FAILURE
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("Error: Encountered a gRPC error while communicating with server - {err}");
+                        ExitCode::FAILURE
+                    }
+                }
+            }
+            Err(err) => {
+                eprintln!("Error: Failed to connect to server - {err}");
+                ExitCode::FAILURE
+            }
+        },
+        Err(err) => {
+            eprintln!("Error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -74,7 +74,7 @@ fn get_arguments() -> Result<(Uri, String), ClientError> {
                 fakeit::user_agent::firefox(),
                 fakeit::user_agent::safari(),
             ];
-            // TODO: The shuffle + clone are currently working around a lifetime issue that I didn't look into
+            // TODO(#8): The shuffle + clone are currently working around a lifetime issue that I didn't look into
             user_agent.shuffle(&mut rng);
             user_agent[0].clone()
         }

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -18,7 +18,7 @@ enum UserAgent {
     Other(String),
 }
 
-// TODO: The ValueEnum stuff in clap doesn't allow for catch-all so we fake it
+// Using `From<String>` because the ValueEnum stuff in clap doesn't allow for catch-all so we fake it
 impl From<String> for UserAgent {
     fn from(s: String) -> Self {
         match s.to_ascii_lowercase().as_str() {

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -86,7 +86,7 @@ fn get_arguments() -> Result<(Uri, String), ClientError> {
 #[tokio::main]
 async fn main() -> ExitCode {
     // TODO(#4): Come up with an abstraction that could "unwrap" errors but still print the error messages we want
-    // TODO: Abstract the various Result returning functions so they return our `ClientError` types instead of hardcoding the error messages
+    // TODO(#9): Abstract the various Result returning functions so they return our `ClientError` types instead of hardcoding the error messages
     // This pyramid was needed because the rust runtime debug prints the message instead of display printing it for Result return types
     match get_arguments() {
         Ok((url, user_agent)) => match ValidateClient::connect(url).await {


### PR DESCRIPTION
This adds a new CLI binary that connects to `ua-detect-server` gRPC endpoint to test various user agents. If you run the client CLI without a user agent, a random UA is selected. If you run it with `chrome`, `firefox`, `opera`, or `safari`, a random UA for that browser is generated. If you run it with a full UA, it is used directly (don't forget to quote it!).